### PR TITLE
Update python support to 3.10, 3.11 and 3.12

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -30,16 +30,6 @@ jobs:
       with:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
-    - name: Set up Python 3.9
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.9'
-    - name: Build and test (3.9)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
-      shell: bash
-      run: |
-        ./.github/workflows/build-test nomypy
     - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
@@ -61,6 +51,16 @@ jobs:
         python-version: '3.11'
     - name: Build and test (3.11)
       if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+      shell: bash
+      run: |
+        ./.github/workflows/build-test nomypy
+    - name: Set up Python 3.12
+      if: github.event_name == 'push' || github.event_name == 'schedule'
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.12'
+    - name: Build and test (3.12)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,36 +31,36 @@ jobs:
         fetch-depth: '0'
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
-    - name: Build and test including remote checks (3.10) mypy
-      if:  (matrix.os == 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
-      shell: bash
-      run: |
-        ./.github/workflows/build-test mypy
-    - name: Build and test including remote checks (3.10) nomypy
-      if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
+    - name: Build and test (3.10)
+      if: github.event_name == 'push' || github.event_name == 'schedule'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.11
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
-    - name: Build and test (3.11)
-      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
+    - name: Build and test including remote checks (3.11) mypy
+      if:  (matrix.os == 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule' )
+      shell: bash
+      run: |
+        ./.github/workflows/build-test mypy
+    - name: Build and test including remote checks (3.11) nomypy
+      if:  (matrix.os != 'macos-12') && (github.event_name == 'push' || (github.event_name == 'pull_request' &&  github.event.pull_request.head.repo.full_name == github.repository) || github.event_name == 'release' || github.event_name == 'schedule')
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy
     - name: Set up Python 3.12
-      if: github.event_name == 'push' || github.event_name == 'schedule'
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       uses: actions/setup-python@v5
       with:
         python-version: '3.12'
     - name: Build and test (3.12)
-      if: github.event_name == 'push' || github.event_name == 'schedule'
+      if: github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule'
       shell: bash
       run: |
         ./.github/workflows/build-test nomypy

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python 3.10
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.10'
     - name: Upgrade pip and install wheel
       run: pip install --upgrade pip wheel
     - name: Install pytket cirq

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Cirq representations.
 
 ## Getting started
 
-`pytket-cirq` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS
+`pytket-cirq` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS
 and Windows. To install, run:
 
 ```shell

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,8 @@ Unreleased
 --------------------
 
 * Implement ``backend_info`` property.
+* Python 3.12 support added, 3.9 dropped.
+* pytket dependency updated to 1.24
 
 0.32.0 (November 2023)
 ----------------------

--- a/docs/intro.txt
+++ b/docs/intro.txt
@@ -7,7 +7,7 @@ quantum circuits and running them on simulators and physical quantum devices.
 ``pytket-cirq`` is an extension to ``pytket`` that allows conversion to and from
 Cirq representations.
 
-``pytket-cirq`` is available for Python 3.9, 3.10 and 3.11, on Linux, MacOS and
+``pytket-cirq`` is available for Python 3.10, 3.11 and 3.12, on Linux, MacOS and
 Windows. To install, run:
 
 ::

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,9 @@ setup(
     ],
     classifiers=[
         "Environment :: Console",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ setup(
     packages=find_namespace_packages(include=["pytket.*"]),
     include_package_data=True,
     install_requires=[
-        "pytket ~= 1.23.0rc0",
+        "pytket ~= 1.24",
         "cirq-core ~= 1.0",
         "cirq-google ~= 1.0",
         "protobuf >= 3.20, < 5.0",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     version=metadata["__extension_version__"],
     author="TKET development team",
     author_email="tket-support@cambridgequantum.com",
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     project_urls={
         "Documentation": "https://tket.quantinuum.com/extensions/pytket-cirq/index.html",
         "Source": "https://github.com/CQCL/pytket-cirq",


### PR DESCRIPTION
This PR drops python 3.9 support and adds python 3.12.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [x] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the changelog with any user-facing changes.
