### PR TITLE
Add docs coverage and warning checks to CI and resolve failures for both

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -28,7 +28,7 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
-        submodules: true
+        submodules: recursive
     - run: git fetch --depth=1 origin +refs/tags/*:refs/tags/* +refs/heads/*:refs/remotes/origin/*
     - name: Set up Python 3.10
       if: github.event_name == 'push' || github.event_name == 'schedule'

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         cd docs
         bash ./install.sh
-        for w in `find wheelhouse/ -type f -name "*.whl"` ; do poetry install $w ; done
+        poetry run pip install ../.
     - name: Build docs
       if:  (matrix.os == 'ubuntu-latest') && (github.event_name == 'pull_request' || github.event_name == 'schedule' )
       timeout-minutes: 20

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,28 +2,38 @@ API documentation
 ~~~~~~~~~~~~~~~~~
 
 .. automodule:: pytket.extensions.cirq
-    :members: cirq_to_tk, tk_to_cirq, process_characterisation
 
-.. autoclass:: pytket.extensions.cirq.CirqStateSampleBackend
+.. automodule:: pytket.extensions.cirq._metadata
+.. automodule:: pytket.extensions.cirq.backends
+.. automodule:: pytket.extensions.cirq.backends.cirq_utils
+.. automodule:: pytket.extensions.cirq.backends.cirq_convert
+
+   .. autofunction:: cirq_to_tk
+   .. autofunction:: tk_to_cirq
+   .. autofunction:: process_characterisation
+
+.. automodule:: pytket.extensions.cirq.backends.cirq
+
+.. autoclass:: pytket.extensions.cirq.backends.cirq.CirqStateSampleBackend
     :inherited-members:
     :members:
 
-.. autoclass:: pytket.extensions.cirq.CirqDensityMatrixSampleBackend
+.. autoclass:: pytket.extensions.cirq.backends.cirq.CirqDensityMatrixSampleBackend
     :inherited-members:
     :members:
 
-.. autoclass:: pytket.extensions.cirq.CirqCliffordSampleBackend
+.. autoclass:: pytket.extensions.cirq.backends.cirq.CirqCliffordSampleBackend
     :inherited-members:
     :members:
 
-.. autoclass:: pytket.extensions.cirq.CirqStateSimBackend
+.. autoclass:: pytket.extensions.cirq.backends.cirq.CirqStateSimBackend
     :inherited-members:
     :members:
 
-.. autoclass:: pytket.extensions.cirq.CirqDensityMatrixSimBackend
+.. autoclass:: pytket.extensions.cirq.backends.cirq.CirqDensityMatrixSimBackend
     :inherited-members:
     :members:
 
-.. autoclass:: pytket.extensions.cirq.CirqCliffordSimBackend
+.. autoclass:: pytket.extensions.cirq.backends.cirq.CirqCliffordSimBackend
     :inherited-members:
     :members:

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -13,7 +13,9 @@ EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
 
 # Build the docs. Ensure we have the correct project title.
-sphinx-build -b html -D html_title="$EXTENSION_NAME" . build 
+sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
+
+sphinx-build -W -v -b coverage . build/coverage || exit 1
 
 # Remove copied files. This ensures reusability.
 rm -r _static 

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -9,9 +9,6 @@ cp pytket-docs-theming/conf.py .
 # Get the name of the project
 EXTENSION_NAME="$(basename "$(dirname `pwd`)")"
 
-# Correct github link in navbar
-sed -i '' 's#CQCL/tket#CQCL/'$EXTENSION_NAME'#' _static/nav-config.js
-
 # Build the docs. Ensure we have the correct project title.
 sphinx-build -W -b html -D html_title="$EXTENSION_NAME" . build || exit 1
 

--- a/pytket/extensions/cirq/__init__.py
+++ b/pytket/extensions/cirq/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Module for conversion between Google Cirq and tket primitives."""
 
 # _metadata.py is copied to the folder after installation.
 from ._metadata import __extension_name__, __extension_version__

--- a/pytket/extensions/cirq/backends/__init__.py
+++ b/pytket/extensions/cirq/backends/__init__.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Backends for connecting to Cirq simulators directly from pytket"""
 
 from .cirq import (
     CirqCliffordSampleBackend,

--- a/pytket/extensions/cirq/backends/cirq.py
+++ b/pytket/extensions/cirq/backends/cirq.py
@@ -17,6 +17,8 @@ from collections.abc import Sequence
 from typing import cast
 from uuid import uuid4
 
+# Base cirq needed for sphinx to resolve type annotations
+import cirq  # noqa: F401
 from cirq import ops
 from cirq.circuits import Circuit as CirqCircuit
 from cirq.devices import NOISE_MODEL_LIKE
@@ -256,13 +258,9 @@ class _CirqSimBackend(_CirqBaseBackend):
         self, circuit: CirqCircuit, q_bits: Sequence[Qubit]
     ) -> BackendResult:
         """
-
-        :param circuit: The circuit to simulate.
-        :type circuit: CirqCircuit
+        :param circuit: The cirq circuit to simulate.
         :param q_bits: ordered pytket Qubit
-        :type q_bits: Sequence[Qubit]
         :return: result of simulation
-        :rtype: BackendResult
         """
         ...
 
@@ -299,12 +297,9 @@ class _CirqSimBackend(_CirqBaseBackend):
     ) -> list[BackendResult]:
         """
 
-        :param circuit: The circuit to simulate.
-        :type circuit: CirqCircuit
+        :param circuit: The cirq circuit to simulate.
         :param q_bits: ordered pytket Qubit
-        :type q_bits: Sequence[Qubit]
         :return: sequence of moments from simulator
-        :rtype: List[BackendResult]
         """
         ...
 
@@ -320,8 +315,16 @@ class _CirqSimBackend(_CirqBaseBackend):
         **kwargs: KwargTypes,
     ) -> ResultHandle:
         """
-        Submit a single circuit to the backend for running. See
-        :py:meth:`_CirqSimBackend.process_circuits_moments`.
+        Submit a circuit to the backend for running. The results will be stored
+        in the backend's result cache to be retrieved by the corresponding
+        get_<data> method. The get_<data> method will return List[BackendResult]
+        corresponding to each moment.
+
+        :param circuit: Circuit to process on the backend.
+        :param valid_check: Explicitly check that all circuits satisfy all required
+            predicates to run on the backend. Defaults to True
+        :return: Handles to results for each input circuit, as an interable in
+            the same order as the circuits.
         """
 
         return self.process_circuits_moments(
@@ -341,13 +344,10 @@ class _CirqSimBackend(_CirqBaseBackend):
         corresponding to each moment.
 
         :param circuits: Circuits to process on the backend.
-        :type circuits: Iterable[Circuit]
         :param valid_check: Explicitly check that all circuits satisfy all required
             predicates to run on the backend. Defaults to True
-        :type valid_check: bool, optional
         :return: Handles to results for each input circuit, as an interable in
             the same order as the circuits.
-        :rtype: List[ResultHandle]
         """
 
         if valid_check:

--- a/pytket/extensions/cirq/backends/cirq_convert.py
+++ b/pytket/extensions/cirq/backends/cirq_convert.py
@@ -12,11 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Methods to allow conversion between Cirq and tket data types, including Circuits and
-Devices
-"""
-
 import cmath
 import re
 from logging import warning
@@ -100,14 +95,14 @@ _cirq2ops_radians_mapping = {
 
 
 def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:  # noqa: PLR0912, PLR0915
-    """Converts a Cirq :py:class:`cirq.Circuit` to a tket :py:class:`pytket._tket.circuit.Circuit` object.
+    """Converts a Cirq :py:class:`cirq.Circuit` to a tket :py:class:`~.pytket._tket.circuit.Circuit` object.
 
     :param circuit: The input Cirq :py:class:`cirq.Circuit`
 
     :raises NotImplementedError: If the input contains a Cirq :py:class:`cirq.Circuit`
         operation which is not yet supported by pytket
 
-    :return: The tket :py:class:`pytket._tket.circuit.Circuit` corresponding to the input circuit
+    :return: The tket :py:class:`~.pytket._tket.circuit.Circuit` corresponding to the input circuit
     """
     tkcirc = Circuit()
     qmap = {}
@@ -219,9 +214,9 @@ def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:  # noqa: PLR0912, PLR
 
 
 def tk_to_cirq(tkcirc: Circuit, copy_all_qubits: bool = False) -> cirq.circuits.Circuit:  # noqa: PLR0912, PLR0915
-    """Converts a tket :py:class:`pytket._tket.circuit.Circuit` object to a Cirq :py:class:`cirq.Circuit`.
+    """Converts a tket :py:class:`~.pytket._tket.circuit.Circuit` object to a Cirq :py:class:`cirq.Circuit`.
 
-    :param tkcirc: The input tket :py:class:`pytket._tket.circuit.Circuit`
+    :param tkcirc: The input tket :py:class:`~.pytket._tket.circuit.Circuit`
 
     :return: The Cirq :py:class:`cirq.Circuit` corresponding to the input circuit
     """

--- a/pytket/extensions/cirq/backends/cirq_convert.py
+++ b/pytket/extensions/cirq/backends/cirq_convert.py
@@ -21,6 +21,7 @@ import cirq_google
 from sympy import Basic, Symbol, pi
 
 import cirq.ops
+from cirq import Qid
 from cirq.devices import GridQubit, LineQubit
 from pytket.architecture import Architecture
 from pytket.circuit import Bit, Circuit, Node, OpType, Qubit
@@ -105,7 +106,7 @@ def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:  # noqa: PLR0912, PLR
     :return: The tket :py:class:`~.pytket._tket.circuit.Circuit` corresponding to the input circuit
     """
     tkcirc = Circuit()
-    qmap = {}
+    qmap: dict[Qid, Qubit] = {}
     for qb in circuit.all_qubits():
         if isinstance(qb, LineQubit):
             uid = Qubit("q", qb.x)

--- a/pytket/extensions/cirq/backends/cirq_convert.py
+++ b/pytket/extensions/cirq/backends/cirq_convert.py
@@ -100,14 +100,14 @@ _cirq2ops_radians_mapping = {
 
 
 def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:  # noqa: PLR0912, PLR0915
-    """Converts a Cirq :py:class:`Circuit` to a tket :py:class:`Circuit` object.
+    """Converts a Cirq :py:class:`cirq.Circuit` to a tket :py:class:`pytket._tket.circuit.Circuit` object.
 
-    :param circuit: The input Cirq :py:class:`Circuit`
+    :param circuit: The input Cirq :py:class:`cirq.Circuit`
 
-    :raises NotImplementedError: If the input contains a Cirq :py:class:`Circuit`
+    :raises NotImplementedError: If the input contains a Cirq :py:class:`cirq.Circuit`
         operation which is not yet supported by pytket
 
-    :return: The tket :py:class:`Circuit` corresponding to the input circuit
+    :return: The tket :py:class:`pytket._tket.circuit.Circuit` corresponding to the input circuit
     """
     tkcirc = Circuit()
     qmap = {}
@@ -219,11 +219,11 @@ def cirq_to_tk(circuit: cirq.circuits.Circuit) -> Circuit:  # noqa: PLR0912, PLR
 
 
 def tk_to_cirq(tkcirc: Circuit, copy_all_qubits: bool = False) -> cirq.circuits.Circuit:  # noqa: PLR0912, PLR0915
-    """Converts a tket :py:class:`Circuit` object to a Cirq :py:class:`Circuit`.
+    """Converts a tket :py:class:`pytket._tket.circuit.Circuit` object to a Cirq :py:class:`cirq.Circuit`.
 
-    :param tkcirc: The input tket :py:class:`Circuit`
+    :param tkcirc: The input tket :py:class:`pytket._tket.circuit.Circuit`
 
-    :return: The Cirq :py:class:`Circuit` corresponding to the input circuit
+    :return: The Cirq :py:class:`cirq.Circuit` corresponding to the input circuit
     """
     if copy_all_qubits:
         tkcirc = tkcirc.copy()
@@ -328,7 +328,7 @@ def process_characterisation(
     device: cirq_google.devices.grid_device.GridDevice,
 ) -> dict:
     """Generates a tket dictionary containing device characteristics for a Cirq
-    :py:class:`GridDevice`.
+    :py:class:`cirq.GridDevice`.
 
     :param device: The device to convert
 

--- a/pytket/extensions/cirq/backends/cirq_convert.py
+++ b/pytket/extensions/cirq/backends/cirq_convert.py
@@ -21,7 +21,6 @@ import cirq_google
 from sympy import Basic, Symbol, pi
 
 import cirq.ops
-from cirq import Qid
 from cirq.devices import GridQubit, LineQubit
 from pytket.architecture import Architecture
 from pytket.circuit import Bit, Circuit, Node, OpType, Qubit

--- a/pytket/extensions/cirq/backends/cirq_utils.py
+++ b/pytket/extensions/cirq/backends/cirq_utils.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared utility methods for cirq backends."""
-
 from typing import cast
 
 from cirq.circuits import Circuit as CirqCircuit


### PR DESCRIPTION
# Description

Adding CI checks for documentation coverage (making sure that every publicly visible method and class - those whose names don't begin with an underscore - is included in the docs) and enforcing sphinx nitpicky to report any formatting failures and broken cross-references.

This PR also resolves existing gaps in coverage and broken formatting. Some of the newly documented content required for docs coverage may have been intended to be internal components required only as part of the conversion or infrastructure code and is not intended for end users; I will need some help spotting any such instances so we can underscore them out to clarify this intention.

# Related issues

This works towards CQCL/tket#1857, following on from CQCL/tket#1910 for the core package and related PRs for other extensions.

# Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have commented hard-to-understand parts of my code.
- [ ] I have made corresponding changes to the public API documentation.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the changelog with any user-facing changes.
